### PR TITLE
Remove downstream error from predefined error types

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -262,7 +262,6 @@ following predefined error codes.
 | `INTERNAL`           | 500         | An internal error occured.                                                                                                       |
 | `NOT_IMPLEMENTED`    | 501         | The server either does not recognize the request method, or it lacks the ability to fulfill the request.                         |
 | `UNAVAILABLE`        | 503         | The service is currently unavailable.                                                                                            |
-| `DOWNSTREAM_ERROR`   | 520         | Used by gateways to report that a downstream server has responded with an error.                                                 |
 | `DOWNSTREAM_TIMEOUT` | 521         | Used by gateways to report that a request to a downstream server has timed out.                                                  |
 
 ## General Purpose Headers

--- a/SPEC.md
+++ b/SPEC.md
@@ -253,7 +253,7 @@ For compatiblity of this HTTP spec with future transports, when a handler fails 
 following predefined error codes.
 
 | Name                 | Status Code | Description                                                                                                                      |
-| -------------------- |-------------| -------------------------------------------------------------------------------------------------------------------------------- |
+| -------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `BAD_REQUEST`        | 400         | The server cannot or will not process the request due to an apparent client error.                                               |
 | `UNAUTHENTICATED`    | 401         | The client did not supply valid authentication credentials for this request.                                                     |
 | `UNAUTHORIZED`       | 403         | The caller does not have permission to execute the specified operation.                                                          |

--- a/SPEC.md
+++ b/SPEC.md
@@ -253,7 +253,7 @@ For compatiblity of this HTTP spec with future transports, when a handler fails 
 following predefined error codes.
 
 | Name                 | Status Code | Description                                                                                                                      |
-| -------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| -------------------- |-------------| -------------------------------------------------------------------------------------------------------------------------------- |
 | `BAD_REQUEST`        | 400         | The server cannot or will not process the request due to an apparent client error.                                               |
 | `UNAUTHENTICATED`    | 401         | The client did not supply valid authentication credentials for this request.                                                     |
 | `UNAUTHORIZED`       | 403         | The caller does not have permission to execute the specified operation.                                                          |
@@ -262,7 +262,7 @@ following predefined error codes.
 | `INTERNAL`           | 500         | An internal error occured.                                                                                                       |
 | `NOT_IMPLEMENTED`    | 501         | The server either does not recognize the request method, or it lacks the ability to fulfill the request.                         |
 | `UNAVAILABLE`        | 503         | The service is currently unavailable.                                                                                            |
-| `DOWNSTREAM_TIMEOUT` | 521         | Used by gateways to report that a request to a downstream server has timed out.                                                  |
+| `DOWNSTREAM_TIMEOUT` | 520         | Used by gateways to report that a request to a downstream server has timed out.                                                  |
 
 ## General Purpose Headers
 


### PR DESCRIPTION
Removing `DOWNSTREAM_ERROR` from the list of predefined handler error types
Changed `DOWNSTREAM_TIMEOUT` to `520`