### PR TITLE
Add Nexus-Operation-Id and Nexus-Link headers to callback definition

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -103,7 +103,7 @@ timeout for a single HTTP request. Format of this header value is number + unit,
 milliseconds, `s` for seconds, and `m` for minutes.
 
 The `Nexus-Link` header field can be added to associate resources with the start request. A handler may attach these
-links as metadata to underlying resources to provide end-to-end observabililty. See the [`Nexus-Link`](#nexus-link)
+links as metadata to underlying resources to provide end-to-end observability. See the [`Nexus-Link`](#nexus-link)
 section for more information.
 
 #### Request Body
@@ -307,6 +307,8 @@ For invoking a callback URL:
 - Include any callback headers supplied in the originating StartOperation request, stripping away the `Nexus-Callback-`
   prefix.
 - Include the `Nexus-Operation-State` header.
+- Include the `Nexus-Operation-Id` header and any `Nexus-Link` headers for resources associated with this operation to
+  support completing asynchronous operations before the response to StartOperation is received.
 - If state is `succeeded`, deliver non-empty results in the body with corresponding `Content-*` headers.
 - If state is `failed` or `canceled`, content type should be `application/json` and the body must have a serialized
   [`Failure`](#failure) object.

--- a/SPEC.md
+++ b/SPEC.md
@@ -306,9 +306,12 @@ For invoking a callback URL:
 - Issue a POST request to the caller-provided URL.
 - Include any callback headers supplied in the originating StartOperation request, stripping away the `Nexus-Callback-`
   prefix.
+- Include the `Nexus-Operation-Id` header, `Nexus-Operation-Start-Time` and any `Nexus-Link` headers for resources
+  associated with this operation to support completing asynchronous operations before the response to StartOperation is
+  received.
+- Format for `Nexus-Operation-Start-Time` is number + unit, where unit can be `ms` for milliseconds, `s` for seconds,
+  and `m` for minutes. If it is omitted, operation start time will be the time the completion is received.
 - Include the `Nexus-Operation-State` header.
-- Include the `Nexus-Operation-Id` header and any `Nexus-Link` headers for resources associated with this operation to
-  support completing asynchronous operations before the response to StartOperation is received.
 - If state is `succeeded`, deliver non-empty results in the body with corresponding `Content-*` headers.
 - If state is `failed` or `canceled`, content type should be `application/json` and the body must have a serialized
   [`Failure`](#failure) object.

--- a/SPEC.md
+++ b/SPEC.md
@@ -308,7 +308,8 @@ For invoking a callback URL:
   prefix.
 - Include the `Nexus-Operation-Id` header, `Nexus-Operation-Start-Time` and any `Nexus-Link` headers for resources
   associated with this operation to support completing asynchronous operations before the response to StartOperation is
-  received. If `Nexus-Operation-Start-Time` is omitted, the time the completion is received will be used.
+  received. `Nexus-Operation-Start-Time` should be in RFC1123 format. If is omitted, the time the completion is
+  received will be used as operation start time.
 - Include the `Nexus-Operation-State` header.
 - If state is `succeeded`, deliver non-empty results in the body with corresponding `Content-*` headers.
 - If state is `failed` or `canceled`, content type should be `application/json` and the body must have a serialized

--- a/SPEC.md
+++ b/SPEC.md
@@ -308,9 +308,7 @@ For invoking a callback URL:
   prefix.
 - Include the `Nexus-Operation-Id` header, `Nexus-Operation-Start-Time` and any `Nexus-Link` headers for resources
   associated with this operation to support completing asynchronous operations before the response to StartOperation is
-  received.
-- Format for `Nexus-Operation-Start-Time` is number + unit, where unit can be `ms` for milliseconds, `s` for seconds,
-  and `m` for minutes. If it is omitted, operation start time will be the time the completion is received.
+  received. If `Nexus-Operation-Start-Time` is omitted, the time the completion is received will be used.
 - Include the `Nexus-Operation-State` header.
 - If state is `succeeded`, deliver non-empty results in the body with corresponding `Content-*` headers.
 - If state is `failed` or `canceled`, content type should be `application/json` and the body must have a serialized

--- a/SPEC.md
+++ b/SPEC.md
@@ -308,8 +308,8 @@ For invoking a callback URL:
   prefix.
 - Include the `Nexus-Operation-Id` header, `Nexus-Operation-Start-Time` and any `Nexus-Link` headers for resources
   associated with this operation to support completing asynchronous operations before the response to StartOperation is
-  received. `Nexus-Operation-Start-Time` should be in a valid HTTP/1.1 format. If is omitted, the time the completion is
-  received will be used as operation start time.
+  received. `Nexus-Operation-Start-Time` should be in a valid HTTP format described [here](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.3).
+  If is omitted, the time the completion is received will be used as operation start time.
 - Include the `Nexus-Operation-State` header.
 - If state is `succeeded`, deliver non-empty results in the body with corresponding `Content-*` headers.
 - If state is `failed` or `canceled`, content type should be `application/json` and the body must have a serialized

--- a/SPEC.md
+++ b/SPEC.md
@@ -308,7 +308,7 @@ For invoking a callback URL:
   prefix.
 - Include the `Nexus-Operation-Id` header, `Nexus-Operation-Start-Time` and any `Nexus-Link` headers for resources
   associated with this operation to support completing asynchronous operations before the response to StartOperation is
-  received. `Nexus-Operation-Start-Time` should be in RFC1123 format. If is omitted, the time the completion is
+  received. `Nexus-Operation-Start-Time` should be in a valid HTTP/1.1 format. If is omitted, the time the completion is
   received will be used as operation start time.
 - Include the `Nexus-Operation-State` header.
 - If state is `succeeded`, deliver non-empty results in the body with corresponding `Content-*` headers.


### PR DESCRIPTION
Added `Nexus-Operation-Id` and `Nexus-Link` headers to callback description. These are needed to support completing async operations before the start operation response is received.