### PR TITLE
Clarify Failure details needs to be JSON serializable.

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -47,7 +47,7 @@ properties:
     type: any
     properties:
     description: |
-      Additional structured data.
+      Additional JSON serializable structured data.
 ```
 
 ### OperationInfo


### PR DESCRIPTION
It can be assumed because of the JSON schema `any` type, but this will remove any chance for confusion.