### PR TITLE
Add Nexus-Request-Retryable header, line wrap spec

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -1,6 +1,9 @@
 {
-  "markdown": {},
+  "markdown": {
+    "lineWidth": 120,
+    "textWrap": "always"
+  },
   "includes": ["*.md"],
   "excludes": [],
-  "plugins": ["https://plugins.dprint.dev/markdown-0.15.3.wasm"]
+  "plugins": ["https://plugins.dprint.dev/markdown-0.17.8.wasm"]
 }


### PR DESCRIPTION
Add an optional `Nexus-Request-Retryable` header to the spec to allow handlers to override the default retry behavior of handler errors. And a recommendation for when to retry every handler error.